### PR TITLE
feat: add watchoption poll to support watchign in NFS filesystems

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -47,5 +47,8 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: '../css/[name].css'
         }),
-    ]
+    ],
+    watchOptions: {
+        poll: 1000 // Check for changes every second
+    }
 };


### PR DESCRIPTION
What this does
- formally adds the `watchOptions: { poll: true }` fix to our shed-cli setup

Why
- Watch options werent working due to windows implementation of iNotify (?) not correctly notifying changes to webpack. `poll` will periodically manually check for changes to the files and alert any watcher processes that require it.